### PR TITLE
Enhance documentation structure with comprehensive guides

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,6 +22,7 @@ To install _docToolchain_, switch to the terminal and run
 ----
 curl -Lo dtcw doctoolchain.github.io/dtcw
 chmod +x dtcw
+./dtcw install java
 ./dtcw install doctoolchain
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,24 +1,53 @@
-== Empty Repository
+= Diagrams-as-Code Workshop
+:toc: left
+:numbered:
+:icons: font
+:experimental:
+:imagesdir: images
 
-This is just an empty repository to play around with some Diagrams-as-Code tools.
+== Über diesen Workshop
 
-To open this repository in gitpod, just preface the URL with `gitpod.io#`.
+Willkommen zum "Diagrams-as-Code" Workshop! Dieser Workshop bietet eine praktische Einführung in verschiedene Tools und Techniken zur Erstellung von Diagrammen mittels Code. Diagramme-als-Code bieten viele Vorteile gegenüber traditionellen grafischen Editoren:
 
-Next, gitpod will start a web based visual studio instance with everything pre-installed.
+* *Versionierung*: Diagramme können wie normaler Code versioniert werden
+* *Wiederverwendbarkeit*: Elemente und Stile können wiederverwendet werden
+* *Automatisierung*: Diagramme können durch CI/CD-Pipelines automatisch generiert werden
+* *Konsistenz*: Einheitliches Design über alle Diagramme hinweg
+* *Textbasiert*: Einfache Bearbeitung in jedem Texteditor
 
-Open this `README.adoc` and press `Ctrl+k` then `v` to aktivate the AsciiDoc preview.
+== Schnellstart
 
-There are some german exercises which can be found at https://doctoolchain.org/empty-workshop/Uebungen.html .
+=== Online mit Gitpod
 
-Now open xref:src/docs/diagrams-as-code.adoc[] and start hacking.
+Der einfachste Weg, diesen Workshop zu starten, ist über Gitpod:
 
-'''
+1. Öffne diese Repository-URL mit dem Präfix `gitpod.io#`:
++
+```
+gitpod.io#https://github.com/docToolchain/empty-workshop
+```
 
-=== advanced
+2. Gitpod startet eine web-basierte Visual Studio Code Instanz mit allen benötigten Erweiterungen.
 
-To install _docToolchain_, switch to the terminal and run
+3. Öffne diese README.adoc-Datei und drücke kbd:[Ctrl+k] gefolgt von kbd:[v], um die AsciiDoc Vorschau zu aktivieren.
 
-[code, bash]
+4. Navigiere zu xref:src/docs/workshop/index.adoc[], um mit dem Workshop zu beginnen.
+
+=== Lokale Installation
+
+Um den Workshop lokal durchzuführen:
+
+1. Klone dieses Repository:
++
+[source, bash]
+----
+git clone https://github.com/docToolchain/empty-workshop.git
+cd empty-workshop
+----
+
+2. Installiere docToolchain:
++
+[source, bash]
 ----
 curl -Lo dtcw doctoolchain.github.io/dtcw
 chmod +x dtcw
@@ -26,11 +55,71 @@ chmod +x dtcw
 ./dtcw install doctoolchain
 ----
 
-To preview the files, start a small server from within the terminal:
-
-[code, bash]
+3. Starte einen lokalen Webserver zur Vorschau der Dokumente:
++
+[source, bash]
 ----
 python -m http.server 8000
 ----
 
-Gitpod will now ask you what to do with the opened port. Just click on "open in browser" and navigate through the `build` folder.
+4. Öffne http://localhost:8000 in deinem Browser.
+
+== Workshopstruktur
+
+Der Workshop ist in folgenden Ordnern und Dateien organisiert:
+
+* `src/docs/workshop/` - Die Hauptdokumente des Workshops
+** `index.adoc` - Startpunkt und Übersicht des Workshops
+** `plantuml/` - Materialien zum PlantUML-Teil des Workshops
+** `drawio/` - Materialien zum draw.io-Teil des Workshops
+** `c4model/` - Materialien zum C4-Modellierung mit verschiedenen Tools
+
+* `src/docs/images/` - Beispielbilder und -diagramme
+* `Uebungen.adoc` - Praktische Übungen (auf Deutsch)
+
+== Unterstützte Diagramm-Tools
+
+In diesem Workshop werden folgende Diagramm-als-Code Tools behandelt:
+
+[cols="1,2,3"]
+|===
+| Tool | Typ | Haupteinsatzgebiete
+
+| PlantUML
+| Textbasierte Diagramme
+| UML-Diagramme, Sequenzdiagramme, Klassendiagramme, u.v.m.
+
+| Draw.io / diagrams.net
+| Grafischer Editor mit Code-Export
+| Freiformdiagramme, Flowcharts, Netzwerkdiagramme
+
+| C4 Model
+| Architekturmodellierung
+| Systemkontext, Container, Komponenten, Codestruktur
+
+| Structurizr
+| DSL für C4 Model
+| Vollständige Systemarchitekturdokumentation
+
+| Kroki.io
+| Diagramm-Rendering-Service
+| Unterstützt zahlreiche Diagrammsprachen
+|===
+
+== Für Trainer und Workshop-Leiter
+
+Wenn du diesen Workshop selbst durchführen möchtest, lies bitte die xref:src/docs/workshop/trainer-guide.adoc[Anleitung für Trainer].
+
+== Beitragende und Lizenz
+
+* Erstellt und gepflegt vom docToolchain-Team
+* Lizensiert unter der link:https://creativecommons.org/licenses/by-sa/4.0/[Creative Commons BY-SA 4.0 Lizenz]
+* Beiträge sind willkommen! Siehe link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] für Details.
+
+== Weiterführende Ressourcen
+
+* link:https://doctoolchain.org/[docToolchain-Website]
+* link:https://arc42.org/[arc42-Website]
+* link:https://crashedmind.github.io/PlantUMLHitchhikersGuide/[PlantUML Hitchhiker's Guide]
+* link:https://c4model.com/[C4 Model]
+* link:https://structurizr.com/[Structurizr]

--- a/src/docs/workshop/basics/introduction.adoc
+++ b/src/docs/workshop/basics/introduction.adoc
@@ -1,0 +1,163 @@
+= Einführung in Diagrams-as-Code
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Was sind Diagrams-as-Code?
+
+*Diagrams-as-Code* ist ein Ansatz, bei dem Diagramme nicht mit grafischen Editoren erstellt werden, sondern durch Code oder textbasierte Beschreibungen. Diese Beschreibungen werden dann automatisch in visuelle Diagramme umgewandelt.
+
+Der grundlegende Ablauf ist:
+
+1. Textbasierte Beschreibung erstellen (in einer speziellen Syntax)
+2. Compiler oder Renderer verarbeitet den Code
+3. Visuelle Darstellung wird generiert (in Formaten wie SVG, PNG, etc.)
+
+== Warum Diagrams-as-Code?
+
+Der Diagrams-as-Code Ansatz bietet gegenüber traditionellen grafischen Editoren zahlreiche Vorteile:
+
+[cols="1,3"]
+|===
+| Vorteil | Beschreibung
+
+| *Versionierung*
+| Diagramme können wie Code in Git versioniert werden. Dies ermöglicht eine transparente Änderungshistorie und eine einfache Zusammenarbeit im Team.
+
+| *Wiederverwendbarkeit*
+| Elemente, Stile und ganze Teildiagramme können wiederverwendet werden, was die Konsistenz erhöht und Zeit spart.
+
+| *Automatisierung*
+| Diagramme können automatisch aus Codebasen oder Datenbanken generiert und in CI/CD-Pipelines integriert werden.
+
+| *Textbasierte Bearbeitung*
+| Diagramme können in jedem Texteditor bearbeitet werden, was die Integration in bestehende Entwicklungsumgebungen erleichtert.
+
+| *Kollaboration*
+| Teams können gemeinsam an Diagrammen arbeiten, indem sie Pull Requests und andere Git-Workflow-Funktionen nutzen.
+
+| *Konsistenz*
+| Durch einheitliche Stile und wiederverwendbare Komponenten wird eine konsistente Darstellung über alle Diagramme hinweg gewährleistet.
+|===
+
+== Unterschied zu traditionellen Diagramm-Tools
+
+[cols="1,1,1"]
+|===
+| Aspekt | Traditionelle Tools | Diagrams-as-Code
+
+| Primäre Bearbeitungsmethode
+| Grafische Benutzeroberfläche
+| Text/Code-Editor
+
+| Dateiformat
+| Oft proprietär oder binär
+| Textbasiert (ASCII/UTF-8)
+
+| Versionierung
+| Schwierig, oft nur auf Dateiebene
+| Einfach, zeilenbasiert wie Code
+
+| Automatisierung
+| Limitiert oder nicht möglich
+| Einfach zu integrieren
+
+| Lernkurve
+| Initial flacher, intuitiver
+| Steiler, erfordert Kenntnis der Syntax
+|===
+
+== Überblick über die wichtigsten Tools
+
+=== PlantUML
+
+PlantUML ist eines der bekanntesten und vielseitigsten Diagrams-as-Code Tools. Es unterstützt eine breite Palette von UML-Diagrammen und anderen Diagrammtypen.
+
+[source,plantuml]
+----
+@startuml
+Alice -> Bob: Authentication Request
+Bob --> Alice: Authentication Response
+Alice -> Bob: Another authentication Request
+Alice <-- Bob: Another authentication Response
+@enduml
+----
+
+=== Draw.io / diagrams.net
+
+Draw.io (jetzt diagrams.net) ist primär ein grafischer Editor, bietet aber auch XML-Export und -Import, was es zu einem Hybrid zwischen traditionellen Editoren und Diagrams-as-Code macht.
+
+=== C4 Model mit verschiedenen Tools
+
+Das C4-Modell ist ein Ansatz zur Beschreibung von Softwarearchitekturen. Es kann mit verschiedenen Tools umgesetzt werden, darunter:
+
+* PlantUML mit C4-Erweiterungen
+* Structurizr, das eine eigene DSL bietet
+* Draw.io mit C4-Bibliotheken
+
+=== Weitere Tools
+
+* Mermaid: JavaScript-basiertes Diagramm-Tool, gut für die Integration in Markdown
+* Graphviz/DOT: Fokus auf automatisches Layout von Graphen
+* AsciiDoctor Diagrams: Integration verschiedener Diagramm-Tools in AsciiDoc
+* Kroki.io: Unified API für verschiedene Diagramm-Sprachen
+
+== Anwendungsbereiche
+
+Diagrams-as-Code eignet sich besonders für:
+
+* Softwarearchitekturdokumentation
+* Infrastrukturdiagramme (z.B. mit IaC)
+* UML-Diagramme in Entwicklungsteams
+* Dynamisch generierte Diagramme (z.B. aus Datenbankschemata)
+* Diagramme, die eng mit Code oder Dokumentation verknüpft sind
+
+== Praxisbeispiel: Ein einfaches Diagramm mit PlantUML
+
+Hier ist ein einfaches Beispiel für ein Komponentendiagramm mit PlantUML:
+
+[source,plantuml]
+----
+@startuml
+package "Frontend" {
+  [Web UI] as UI
+  [API Client] as Client
+}
+
+package "Backend" {
+  [REST API] as API
+  [Business Logic] as Logic
+  [Data Access] as DAO
+}
+
+database "Database" {
+  [SQL Database] as DB
+}
+
+UI --> Client
+Client --> API
+API --> Logic
+Logic --> DAO
+DAO --> DB
+@enduml
+----
+
+Dieses Beispiel zeigt:
+
+1. Definition von Komponenten in Paketen
+2. Beziehungen zwischen den Komponenten
+3. Verschiedene Symboltypen (Komponenten, Datenbank)
+
+== Grundlegende Konzepte zum Mitnehmen
+
+* Diagrams-as-Code ist ein *Paradigma*, kein einzelnes Tool
+* Die *Syntax* variiert je nach verwendetem Tool
+* *Automatisierung* und *Versionierung* sind Hauptvorteile
+* Für komplexe Diagramme ist eine gute *Strukturierung* wichtig
+* *Wiederverwendbarkeit* durch Includes und gemeinsame Stile erreichen
+
+== Nächste Schritte
+
+* Weiter zu xref:advantages.adoc[Vorteile von Diagrams-as-Code]
+* Direkt zu xref:../plantuml/getting-started.adoc[Erste Schritte mit PlantUML]

--- a/src/docs/workshop/c4model/introduction.adoc
+++ b/src/docs/workshop/c4model/introduction.adoc
@@ -1,0 +1,226 @@
+= Einführung in das C4-Modell
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Was ist das C4-Modell?
+
+Das C4-Modell ist ein Ansatz zur Visualisierung und Dokumentation von Softwarearchitekturen, der von Simon Brown entwickelt wurde. C4 steht für die vier Abstraktionsebenen des Modells:
+
+* *Context* (Kontext): Das Gesamtsystem im Kontext seiner Umgebung
+* *Container*: Die hochrangigen technischen Bausteine des Systems
+* *Component* (Komponente): Die logischen Komponenten innerhalb der Container
+* *Code*: Die Implementierungsdetails der Komponenten
+
+Das C4-Modell folgt dem Prinzip des "Zoomens" von einer abstrakten Übersicht bis hin zu detaillierten Implementierungsaspekten.
+
+== Warum C4?
+
+Das C4-Modell wurde entwickelt, um einige der Herausforderungen der Softwarearchitekturdokumentation zu lösen:
+
+* *Einfachheit*: Es verwendet eine verständliche Sprache und klare Konzepte.
+* *Hierarchie*: Die vier Ebenen ermöglichen eine schrittweise Verfeinerung.
+* *Konsistenz*: Eine einheitliche Methodik über verschiedene Projekte hinweg.
+* *Zielgruppenorientierung*: Verschiedene Diagramme für verschiedene Stakeholder.
+
+== Die vier C4-Ebenen im Detail
+
+=== Level 1: Context-Diagramm
+
+Das *Context-Diagramm* zeigt das zu bauende Softwaresystem im Kontext seiner Nutzer und anderer Systeme, mit denen es interagiert.
+
+[plantuml,c4-context-example,svg]
+....
+!include <C4/C4_Context>
+
+LAYOUT_WITH_LEGEND()
+
+title Kontextdiagramm für ein Internet-Banking-System
+
+Person(customer, "Bankkunde", "Ein Kunde der Bank, mit persönlichen Bankkonten.")
+System(banking_system, "Internet-Banking-System", "Ermöglicht Kunden, ihre Konten einzusehen und Transaktionen durchzuführen.")
+
+System_Ext(email_system, "E-Mail-System", "Das interne Microsoft Exchange E-Mail-System.")
+System_Ext(mainframe, "Mainframe-Banksystem", "Speichert alle Kernbankdaten.")
+
+Rel(customer, banking_system, "Nutzt")
+Rel_Back(customer, email_system, "Sendet E-Mails an")
+Rel_Neighbor(banking_system, email_system, "Sendet E-Mails", "SMTP")
+Rel(banking_system, mainframe, "Nutzt")
+....
+
+*Kernelemente:*
+
+* *Personen* - Nutzer oder Rollen, die mit dem System interagieren
+* *Software-Systeme* - Eigenes System und externe Systeme
+* *Beziehungen* - Datenflüsse und Abhängigkeiten zwischen Akteuren
+
+*Zielgruppe:* Alle Stakeholder, insbesondere nicht-technische.
+
+=== Level 2: Container-Diagramm
+
+Das *Container-Diagramm* zooms in das Softwaresystem und zeigt die Container (Anwendungen, Datenspeicher, Microservices), aus denen das System besteht.
+
+[plantuml,c4-container-example,svg]
+....
+!include <C4/C4_Container>
+
+LAYOUT_WITH_LEGEND()
+
+title Container-Diagramm für das Internet-Banking-System
+
+Person(customer, "Bankkunde", "Ein Kunde der Bank, mit persönlichen Bankkonten.")
+
+System_Boundary(banking_system, "Internet-Banking-System") {
+    Container(web_app, "Web-Anwendung", "Java, Spring MVC", "Stellt statische und dynamische Inhalte für Kunden im Browser bereit.")
+    Container(mobile_app, "Mobile App", "Swift, iOS", "Bietet eine eingeschränkte Funktionalität für Kunden unterwegs.")
+    Container(api, "API-Anwendung", "Java, Spring Boot", "Bietet Internet-Banking-Funktionalität über eine JSON/HTTPS-API.")
+    ContainerDb(database, "Datenbank", "Oracle", "Speichert Benutzerregistrierungsinformationen, Audit-Logs, etc.")
+}
+
+System_Ext(mainframe, "Mainframe-Banksystem", "Speichert alle Kernbankdaten.")
+System_Ext(email_system, "E-Mail-System", "Internes Microsoft Exchange-System.")
+
+Rel(customer, web_app, "Nutzt", "HTTPS")
+Rel(customer, mobile_app, "Nutzt")
+Rel(web_app, api, "Nutzt", "JSON/HTTPS")
+Rel(mobile_app, api, "Nutzt", "JSON/HTTPS")
+Rel(api, database, "Liest von und schreibt in", "JDBC")
+Rel(api, mainframe, "Nutzt", "XML/HTTPS")
+Rel(api, email_system, "Sendet E-Mail über", "SMTP")
+....
+
+*Kernelemente:*
+
+* *Container* - Anwendungen, Dienste, Datenbanken usw.
+* *Technologien* - Verwendete Technologien für jeden Container
+* *Kommunikationspfade* - Wie die Container interagieren
+
+*Zielgruppe:* Techniker und Entwickler.
+
+=== Level 3: Component-Diagramm
+
+Das *Component-Diagramm* zooms in einen einzelnen Container und zeigt die wichtigsten Komponenten, aus denen er besteht.
+
+[plantuml,c4-component-example,svg]
+....
+!include <C4/C4_Component>
+
+LAYOUT_WITH_LEGEND()
+
+title Komponentendiagramm für die API-Anwendung
+
+Container_Boundary(api, "API-Anwendung") {
+    Component(sign_in_controller, "Anmeldecontroller", "Spring MVC Rest Controller", "Ermöglicht Benutzern, sich bei der Internet-Banking-Anwendung anzumelden.")
+    Component(accounts_controller, "Kontocontroller", "Spring MVC Rest Controller", "Stellt Kontoübersicht und -details bereit.")
+    Component(security_component, "Sicherheitskomponente", "Spring Bean", "Verwaltet Authentifizierung und Autorisierung.")
+    Component(data_access, "Datenzugriffskomponente", "Spring Bean", "Bietet Zugriff auf die Datenbank.")
+}
+
+ContainerDb(database, "Datenbank", "Oracle", "Speichert Benutzerregistrierungsinformationen, Audit-Logs, etc.")
+System_Ext(mainframe, "Mainframe-Banksystem", "Speichert alle Kernbankdaten.")
+
+Rel(sign_in_controller, security_component, "Nutzt")
+Rel(accounts_controller, security_component, "Nutzt")
+Rel(security_component, data_access, "Nutzt")
+Rel(data_access, database, "Liest von und schreibt in", "JDBC")
+Rel(accounts_controller, mainframe, "Ruft Kontodetails ab", "XML/HTTPS")
+....
+
+*Kernelemente:*
+
+* *Komponenten* - Hauptfunktionale Bausteine innerhalb eines Containers
+* *Verantwortlichkeiten* - Was jede Komponente tut
+* *Schnittstellen* - Wie Komponenten interagieren
+
+*Zielgruppe:* Softwarearchitekten und Entwickler.
+
+=== Level 4: Code-Diagramm
+
+Das *Code-Diagramm* zooms in eine Komponente und zeigt, wie sie implementiert wird, z.B. mit UML-Klassendiagrammen oder Ähnlichem.
+
+[plantuml,c4-code-example,svg]
+....
+@startuml
+package "Sicherheitskomponente" {
+  class SecurityComponent {
+    -userRepository: UserRepository
+    +authenticate(username: String, password: String): boolean
+    +authorize(user: User, resource: String): boolean
+  }
+  
+  interface UserRepository {
+    +findByUsername(username: String): User
+    +save(user: User): void
+  }
+  
+  class JdbcUserRepository implements UserRepository {
+    -dataSource: DataSource
+    +findByUsername(username: String): User
+    +save(user: User): void
+  }
+  
+  class User {
+    -id: Long
+    -username: String
+    -passwordHash: String
+    -roles: List<Role>
+    +hasPermission(resource: String): boolean
+  }
+  
+  class Role {
+    -name: String
+    -permissions: List<Permission>
+  }
+  
+  SecurityComponent --> UserRepository
+  JdbcUserRepository --> User
+  User --> Role
+}
+@enduml
+....
+
+*Kernelemente:*
+
+* *Klassen* - Die tatsächlichen Implementierungsklassen
+* *Beziehungen* - Vererbung, Implementierung, Abhängigkeiten
+* *Details* - Methoden, Attribute, etc.
+
+*Zielgruppe:* Entwickler.
+
+== C4-Modell und Diagramm-als-Code
+
+Das C4-Modell lässt sich hervorragend mit dem Diagrams-as-Code-Ansatz kombinieren:
+
+1. *Versionierung*: Die Architektur kann zusammen mit dem Code versioniert werden
+2. *Automatisierung*: C4-Diagramme können automatisch generiert und aktualisiert werden
+3. *Konsistenz*: Einheitliche Darstellung über alle Projekte hinweg
+
+Es gibt mehrere Tools, die C4 mit Diagrams-as-Code unterstützen:
+
+* *PlantUML mit C4-Makros* - Siehe `!include <C4/...>` in den Beispielen
+* *Structurizr* - Eine spezielle DSL für C4
+* *C4-PlantUML* - Eine Erweiterung für PlantUML mit C4-spezifischer Syntax
+
+== Praktische Übung
+
+1. Erstelle ein Context-Diagramm für ein eigenes Projekt oder ein fiktives System (z.B. ein Online-Shop).
+2. Identifiziere die Container in diesem System und erstelle ein Container-Diagramm.
+
+*Tipps:*
+* Beginne mit wenigen Elementen und erweitere schrittweise
+* Denke an die Zielgruppe des jeweiligen Diagramms
+* Achte auf konsistente Benennungen über alle Ebenen hinweg
+
+== Weiterführende Ressourcen
+
+* link:https://c4model.com/[Offizielle C4-Modell Website]
+* link:https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML GitHub Repository]
+* link:https://structurizr.com/[Structurizr]
+* link:https://www.infoq.com/articles/C4-architecture-model/[InfoQ-Artikel über das C4-Modell]
+
+== Nächste Schritte
+
+* Weiter zu xref:with-plantuml.adoc[C4 mit PlantUML]
+* Oder zurück zu xref:../index.adoc[Workshop-Übersicht]

--- a/src/docs/workshop/c4model/introduction.adoc
+++ b/src/docs/workshop/c4model/introduction.adoc
@@ -60,7 +60,7 @@ Rel(banking_system, mainframe, "Nutzt")
 
 === Level 2: Container-Diagramm
 
-Das *Container-Diagramm* zooms in das Softwaresystem und zeigt die Container (Anwendungen, Datenspeicher, Microservices), aus denen das System besteht.
+Das *Container-Diagramm* zoomt in das Softwaresystem und zeigt die Container (Anwendungen, Datenspeicher, Microservices), aus denen das System besteht.
 
 [plantuml,c4-container-example,svg]
 ....
@@ -101,7 +101,7 @@ Rel(api, email_system, "Sendet E-Mail über", "SMTP")
 
 === Level 3: Component-Diagramm
 
-Das *Component-Diagramm* zooms in einen einzelnen Container und zeigt die wichtigsten Komponenten, aus denen er besteht.
+Das *Component-Diagramm* zoomt in einen einzelnen Container und zeigt die wichtigsten Komponenten, aus denen er besteht.
 
 [plantuml,c4-component-example,svg]
 ....
@@ -138,7 +138,7 @@ Rel(accounts_controller, mainframe, "Ruft Kontodetails ab", "XML/HTTPS")
 
 === Level 4: Code-Diagramm
 
-Das *Code-Diagramm* zooms in eine Komponente und zeigt, wie sie implementiert wird, z.B. mit UML-Klassendiagrammen oder Ähnlichem.
+Das *Code-Diagramm* zoomt in eine Komponente und zeigt, wie sie implementiert wird, z.B. mit UML-Klassendiagrammen oder Ähnlichem.
 
 [plantuml,c4-code-example,svg]
 ....

--- a/src/docs/workshop/drawio/getting-started.adoc
+++ b/src/docs/workshop/drawio/getting-started.adoc
@@ -1,0 +1,202 @@
+= Erste Schritte mit Draw.io
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Was ist Draw.io?
+
+Draw.io (auch bekannt als diagrams.net) ist ein kostenloses, quelloffenes Diagramm-Tool, das sowohl online als auch als Desktop-Anwendung genutzt werden kann. Im Gegensatz zu rein textbasierten Diagramm-Tools wie PlantUML bietet Draw.io eine grafische Benutzeroberfläche zum Erstellen von Diagrammen.
+
+Was Draw.io besonders für den Diagrams-as-Code Ansatz wertvoll macht, ist seine Fähigkeit, Diagramme im XML-Format zu speichern und zu bearbeiten, sowie die mögliche Integration in Code-Repositories.
+
+=== Hauptmerkmale von Draw.io
+
+* Intuitive grafische Benutzeroberfläche
+* Rein browserbasiert (keine Installation nötig) oder als Desktop-App
+* Unterstützt zahlreiche Diagrammtypen und Bibliotheken
+* Speichert Diagramme im XML-Format, was Versionierung ermöglicht
+* Integration in VS Code, verschiedene Cloud-Dienste und Atlassian-Produkte
+* Export in verschiedene Formate (PNG, SVG, PDF, HTML, etc.)
+* Kompatibilität mit anderen Diagramm-Tools (z.B. Lucidchart, Visio)
+
+== Zugang zu Draw.io
+
+=== Online-Nutzung
+
+Draw.io kann direkt im Browser verwendet werden, ohne Anmeldung oder Installation:
+
+* link:https://app.diagrams.net/[diagrams.net] (offizieller Name für Draw.io)
+
+=== Desktop-Anwendung
+
+Für die Offline-Nutzung gibt es eine Desktop-Version für verschiedene Plattformen:
+
+* link:https://github.com/jgraph/drawio-desktop/releases[Download der Desktop-App]
+
+=== Integration in VS Code
+
+In diesem Workshop verwenden wir die VS Code-Integration:
+
+1. Die Erweiterung "Draw.io Integration" von Henning Dieterichs installieren
+2. `.drawio` oder `.dio` Dateien in VS Code erstellen oder öffnen
+3. Die Diagramme direkt im VS Code-Editor bearbeiten
+
+== Die Benutzeroberfläche
+
+Die Draw.io-Benutzeroberfläche besteht aus mehreren Hauptbereichen:
+
+* *Arbeitsfläche*: Zentraler Bereich zum Erstellen von Diagrammen
+* *Menüleiste*: Enthält Funktionen für Datei, Bearbeiten, Ansicht, etc.
+* *Seitenleiste*: Bibliotheken mit Formen und Symbolen
+* *Formatierungsleiste*: Optionen zur Formatierung von Elementen
+* *Statusleiste*: Informationen über das Diagramm und aktuelle Aktionen
+
+=== Wichtige Funktionen
+
+* *Bibliotheken*: Vordefinierte Symbole und Formen für verschiedene Diagrammtypen
+* *Stile*: Anpassung von Farben, Linien, Füllungen, etc.
+* *Verbindungen*: Verschiedene Arten von Pfeilen und Verbindungen
+* *Ebenen*: Organisation von Elementen in Schichten
+* *Hyperlinks*: Verlinkung zwischen Diagrammen oder zu externen Ressourcen
+
+== Grafiken erstellen mit Draw.io
+
+=== Neues Diagramm beginnen
+
+In VS Code:
+
+1. `.dio` oder `.drawio` Datei erstellen
+2. Vorlage auswählen oder mit einem leeren Diagramm beginnen
+
+=== Grundlegende Elemente hinzufügen
+
+1. Formen durch Drag & Drop aus der Seitenleiste hinzufügen
+2. Text hinzufügen durch Doppelklick auf Elemente
+3. Elemente verbinden durch Ziehen von Verbindungspunkten
+4. Elemente formatieren über die Formatierungsleiste oder Kontextmenü
+
+=== Bibliotheken verwenden
+
+Draw.io verfügt über zahlreiche eingebaute Bibliotheken:
+
+* Allgemeine Formen
+* UML-Elemente
+* Netzwerk-Komponenten
+* C4-Modell-Komponenten
+* AWS-, Azure-, GCP-Icons
+* Und viele mehr...
+
+So fügst du eine Bibliothek hinzu:
+
+1. Auf das "+"-Symbol in der linken Seitenleiste klicken
+2. Gewünschte Bibliothek auswählen
+3. Die Bibliothek erscheint in der Seitenleiste
+
+== Draw.io und Diagrams-as-Code
+
+Obwohl Draw.io primär ein grafisches Tool ist, passt es gut zum Diagrams-as-Code Ansatz:
+
+=== XML-Basierte Dateien
+
+Draw.io speichert Diagramme im XML-Format, was mehrere Vorteile bietet:
+
+* Textbasiertes Format, gut für Versionskontrolle geeignet
+* Menschenlesbar und bei Bedarf manuell editierbar
+* Kompakt und effizient für die Speicherung
+
+Beispiel für das XML-Format einer einfachen Draw.io-Datei:
+
+[source,xml]
+----
+<mxfile>
+  <diagram id="sample-diagram" name="Page-1">
+    <mxGraphModel dx="1024" dy="768" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        <mxCell id="2" value="Beispielbox" style="rounded=0;whiteSpace=wrap;html=1;" vertex="1" parent="1">
+          <mxGeometry x="350" y="310" width="120" height="60" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>
+----
+
+=== Integration in Git-Workflows
+
+1. Draw.io-Dateien in Git-Repositorys speichern
+2. Änderungen nachverfolgen mit normalen Git-Befehlen
+3. Pull Requests für Diagrammänderungen erstellen
+4. Diagramme gemeinsam mit dem Code entwickeln
+
+=== Automatisierung
+
+Draw.io bietet auch Möglichkeiten zur Automatisierung:
+
+* Command-Line-Rendering mit der Desktop-Version
+* Integration in CI/CD-Pipelines für automatische Diagrammaktualisierung
+* Programmgesteuerte Erstellung und Bearbeitung von Diagrammen
+
+== Praktisches Beispiel: Systemkontext mit Draw.io
+
+Lass uns ein einfaches Systemkontext-Diagramm erstellen:
+
+1. Neue Datei `system-context.drawio` erstellen
+2. Aus der Bibliothek "Softwareentwicklung > C4" auswählen
+3. Elemente hinzufügen:
+   * Person (Benutzer)
+   * System (Kernkomponente)
+   * External System (externe Systeme)
+4. Mit Pfeilen verbinden und Beschreibungen hinzufügen
+
+image::drawio-example-system-context.png[Beispiel eines Systemkontext-Diagramms mit Draw.io]
+
+== Tipps & Tricks
+
+=== Effiziente Arbeitsweise
+
+* *Tastenkürzel* lernen (z.B. Strg+D zum Duplizieren)
+* *Vorlagen* erstellen für wiederkehrende Diagramme
+* *Bibliotheken* anpassen und eigene erstellen
+* *Stile* speichern und wiederverwenden
+
+=== Diagramme zwischen Anwendungen teilen
+
+* Diagramme lassen sich zwischen der Online-Version, Desktop-App und VS Code-Erweiterung austauschen
+* Bibliotheken können exportiert und importiert werden
+* Team-Bibliotheken für konsistente Diagramme einrichten
+
+=== Integration mit anderen Tools
+
+* Git-basierte Workflows
+* Einbindung in Dokumentation (AsciiDoc, Markdown)
+* Exportieren für Präsentationen
+
+== Vor- und Nachteile gegenüber textbasierten Tools
+
+=== Vorteile von Draw.io
+
+* Intuitive grafische Benutzeroberfläche
+* Keine Syntax zu lernen
+* Freie Platzierung und Layout
+* Unterstützung für komplexe Designs und Anpassungen
+
+=== Nachteile gegenüber rein textbasierten Tools
+
+* Weniger strukturiert für systematische Diagramme
+* Schwieriger zu automatisieren
+* XML kann bei komplexen Diagrammen unübersichtlich werden
+* Merge-Konflikte können schwieriger zu lösen sein
+
+== Weiterführende Ressourcen
+
+* link:https://www.diagrams.net/doc/[Offizielle Draw.io-Dokumentation]
+* link:https://desk.draw.io/support/solutions/articles/16000042546[Draw.io Tastenkürzel]
+* link:https://www.youtube.com/c/diagramsnet[Draw.io YouTube-Kanal mit Tutorials]
+
+== Nächste Schritte
+
+* Weiter zu xref:code-integration.adoc[Code-Integration in Draw.io]
+* Oder zurück zu xref:../index.adoc[Workshop-Übersicht]

--- a/src/docs/workshop/index.adoc
+++ b/src/docs/workshop/index.adoc
@@ -1,0 +1,87 @@
+= Diagrams-as-Code Workshop
+:toc: left
+:numbered:
+:icons: font
+:experimental:
+:imagesdir: ../images
+
+== Willkommen zum Workshop
+
+Dieser Workshop führt dich in die Welt der "Diagrams-as-Code" ein. Du wirst lernen, wie du verschiedene Arten von Diagrammen mit Code erstellen, versionieren und automatisieren kannst.
+
+== Workshop-Übersicht
+
+Der Workshop ist in folgende Abschnitte unterteilt:
+
+* *Grundlagen*: Einführung und Konzepte hinter Diagrams-as-Code
+* *PlantUML*: Erstellen von UML-Diagrammen mit PlantUML
+* *Draw.io/diagrams.net*: Nutzung des grafischen Editors mit Code-Integration
+* *C4 Modellierung*: Architekturmodellierung mit dem C4-Ansatz
+* *Integration*: Einbindung der Diagramme in Dokumentation
+
+Zu jedem Abschnitt gibt es praktische Übungen, die dir helfen, das Gelernte anzuwenden.
+
+== Voraussetzungen
+
+=== Technische Voraussetzungen
+
+* Git-Grundkenntnisse
+* Texteditor (idealerweise mit Syntax-Highlighting für die verwendeten Sprachen)
+* Java Runtime Environment (für PlantUML)
+* Web-Browser (für draw.io und andere webbasierte Tools)
+
+=== Empfohlene Entwicklungsumgebungen
+
+* *Online*: Gitpod (alle notwendigen Tools vorinstalliert)
+* *Lokal*: Visual Studio Code mit folgenden Erweiterungen:
+** AsciiDoctor Extension (für die Dokumentation)
+** PlantUML Extension (für PlantUML-Diagramme)
+** Draw.io Extension (für Draw.io-Diagramme)
+
+== Workshop-Module
+
+=== Modul 1: Grundlagen
+
+* xref:basics/introduction.adoc[Einführung in Diagrams-as-Code]
+* xref:basics/advantages.adoc[Vorteile gegenüber grafischen Editoren]
+* xref:basics/version-control.adoc[Versionierung von Diagrammen]
+
+=== Modul 2: PlantUML
+
+* xref:plantuml/getting-started.adoc[Erste Schritte mit PlantUML]
+* xref:plantuml/sequence-diagrams.adoc[Sequenzdiagramme]
+* xref:plantuml/class-diagrams.adoc[Klassendiagramme]
+* xref:plantuml/component-diagrams.adoc[Komponentendiagramme]
+* xref:plantuml/styling.adoc[Styling und Anpassung]
+
+=== Modul 3: Draw.io / diagrams.net
+
+* xref:drawio/getting-started.adoc[Erste Schritte mit Draw.io]
+* xref:drawio/code-integration.adoc[Code-Integration in Draw.io]
+* xref:drawio/collaborative-editing.adoc[Gemeinsames Bearbeiten]
+
+=== Modul 4: C4 Modellierung
+
+* xref:c4model/introduction.adoc[Einführung in das C4-Modell]
+* xref:c4model/with-plantuml.adoc[C4 mit PlantUML]
+* xref:c4model/with-structurizr.adoc[C4 mit Structurizr]
+
+=== Modul 5: Integration in Dokumentation
+
+* xref:integration/asciidoc.adoc[Integration in AsciiDoc]
+* xref:integration/markdown.adoc[Integration in Markdown]
+* xref:integration/automation.adoc[Automatisierung mit CI/CD]
+
+== Praktische Übungen
+
+Jeder Abschnitt enthält praktische Übungen. Du findest alle Übungen in den jeweiligen Modulen oder in der xref:../../Uebungen.adoc[Übungen-Datei].
+
+== Zusätzliche Ressourcen
+
+* xref:resources/examples.adoc[Beispieldiagramme]
+* xref:resources/cheatsheets.adoc[Cheatsheets]
+* xref:resources/links.adoc[Weiterführende Links]
+
+== Nächste Schritte
+
+Beginne mit dem ersten Modul: xref:basics/introduction.adoc[Einführung in Diagrams-as-Code]

--- a/src/docs/workshop/integration/asciidoc.adoc
+++ b/src/docs/workshop/integration/asciidoc.adoc
@@ -1,0 +1,295 @@
+= Integration in AsciiDoc
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Warum Diagramme in Dokumentation integrieren?
+
+Diagramme sind ein mächtiges Mittel, um komplexe Konzepte zu visualisieren und Dokumentation zu verbessern. Die Integration von Diagrams-as-Code in AsciiDoc-Dokumentation bietet mehrere Vorteile:
+
+* *Single Source of Truth*: Diagramme und Dokumentation in einem Repository
+* *Versionierung*: Änderungen an Diagrammen und Dokumentation werden gemeinsam nachverfolgt
+* *Automatisierung*: Automatische Generierung von Diagrammen beim Dokumentationsbuild
+* *Konsistenz*: Einheitliches Erscheinungsbild von Diagrammen in der gesamten Dokumentation
+
+== AsciiDoc und Diagramme
+
+AsciiDoc ist ein leichtgewichtiges Markup-Format für technische Dokumentation, das sich hervorragend für die Integration von Diagrammen eignet. Mit dem AsciiDoctor-Prozessor kann AsciiDoc in verschiedene Ausgabeformate wie HTML, PDF oder EPUB konvertiert werden.
+
+=== AsciiDoctor Diagram Extension
+
+Die AsciiDoctor Diagram Extension ermöglicht die Einbindung verschiedener Diagramm-Tools in AsciiDoc:
+
+* PlantUML
+* Graphviz/DOT
+* Mermaid
+* Ditaa
+* und viele mehr
+
+Die Extension rendert die Diagramme während der Dokumentationsgenerierung und bindet die erzeugten Bilder automatisch ein.
+
+== Integration von PlantUML in AsciiDoc
+
+=== Installation und Konfiguration
+
+Um PlantUML in AsciiDoc zu integrieren, benötigst du:
+
+1. AsciiDoctor: `gem install asciidoctor`
+2. AsciiDoctor Diagram Extension: `gem install asciidoctor-diagram`
+3. Java Runtime Environment (für PlantUML)
+4. PlantUML JAR-Datei
+
+=== Einbetten eines PlantUML-Diagramms
+
+Es gibt zwei Hauptmethoden, um PlantUML-Diagramme in AsciiDoc einzubinden:
+
+==== Methode 1: Inline-Diagramme
+
+Diagramme direkt im AsciiDoc-Dokument definieren:
+
+[source,asciidoc]
+----
+[plantuml,diagram-name,svg]
+....
+@startuml
+Alice -> Bob: Authentifizierungsanfrage
+Bob --> Alice: Authentifizierungsantwort
+@enduml
+....
+----
+
+Die Parameter in den eckigen Klammern bedeuten:
+- `plantuml`: Der Diagrammtyp
+- `diagram-name`: Ein eindeutiger Name für das Diagramm (wird für den Dateinamen verwendet)
+- `svg`: Das Ausgabeformat (alternativ: png, pdf, etc.)
+
+==== Methode 2: Externe Diagrammdateien
+
+Verweis auf externe PlantUML-Dateien:
+
+[source,asciidoc]
+----
+[plantuml,diagram-name,svg]
+....
+include::path/to/diagram.puml[]
+....
+----
+
+oder kürzer:
+
+[source,asciidoc]
+----
+plantuml::path/to/diagram.puml[format=svg]
+----
+
+=== Generierung der Dokumentation
+
+Um die Dokumentation mit eingebetteten Diagrammen zu generieren:
+
+[source,bash]
+----
+asciidoctor -r asciidoctor-diagram document.adoc
+----
+
+Dies erzeugt eine HTML-Datei mit den gerenderten Diagrammen.
+
+== Integration von Draw.io in AsciiDoc
+
+=== Vorbereitung der Draw.io-Dateien
+
+1. Diagramm in Draw.io erstellen
+2. Als SVG oder PNG exportieren
+3. Optional: Verweise und Hyperlinks im Diagramm definieren
+
+=== Einbinden in AsciiDoc
+
+==== Als Bild einbinden
+
+[source,asciidoc]
+----
+image::path/to/diagram.svg[Diagramm-Beschreibung]
+----
+
+==== Mit interaktiven Elementen (SVG)
+
+Für SVG-Dateien mit interaktiven Elementen:
+
+[source,asciidoc]
+----
+// Aktuellen imagesdir speichern
+:currentImagesDir: {imagesdir}
+// Temporär auf den tatsächlichen Pfad umstellen
+:imagesdir: path/to/images/directory
+image::diagram.svg[opts=interactive]
+// Zurück zum ursprünglichen imagesdir
+:imagesdir: {currentImagesDir}
+----
+
+Die Option `opts=interactive` behält interaktive Elemente wie Hyperlinks im SVG bei.
+
+== Integration von C4-Diagrammen
+
+C4-Diagramme können mit verschiedenen Tools erstellt und dann in AsciiDoc integriert werden:
+
+=== Mit PlantUML und C4-Makros
+
+[source,asciidoc]
+----
+[plantuml,c4-context,svg]
+....
+!include <C4/C4_Context>
+
+LAYOUT_WITH_LEGEND()
+
+Person(user, "Benutzer", "Ein Benutzer des Systems")
+System(system, "Mein System", "Das zu bauende Softwaresystem")
+System_Ext(external, "Externes System", "Ein externes System")
+
+Rel(user, system, "Benutzt")
+Rel(system, external, "Nutzt API von")
+....
+----
+
+=== Mit Structurizr und DSL
+
+1. Structurizr DSL verwenden, um Diagramme zu definieren
+2. Diagramme als PNG oder SVG exportieren
+3. In AsciiDoc einbinden
+
+[source,asciidoc]
+----
+image::structurizr-context.svg[C4 Kontextdiagramm]
+----
+
+== Automatisierung mit docToolchain
+
+docToolchain ist ein Open-Source-Tool, das die Dokumentationserstellung mit AsciiDoc automatisiert und erweitert. Es ist besonders nützlich für die Integration von Diagrammen.
+
+=== Vorteile von docToolchain
+
+* Automatische Generierung von Diagrammen
+* Build-Pipeline für Dokumentation
+* Exportieren von Diagrammen aus verschiedenen Quellen (Excel, PlantUML, etc.)
+* Integration in CI/CD-Pipelines
+
+=== Einrichtung von docToolchain
+
+1. docToolchain installieren:
+
+[source,bash]
+----
+curl -Lo dtcw doctoolchain.github.io/dtcw
+chmod +x dtcw
+./dtcw install java
+./dtcw install doctoolchain
+----
+
+2. Dokumentation generieren:
+
+[source,bash]
+----
+./dtcw generateHTML
+----
+
+=== Diagramme aus Excel generieren
+
+docToolchain kann auch Diagramme aus Excel-Dateien generieren:
+
+[source,bash]
+----
+./dtcw exportExcel
+----
+
+Die generierten Diagramme werden als AsciiDoc-Dateien im Verzeichnis `src/docs/excel` abgelegt und können dann in die Hauptdokumentation eingebunden werden.
+
+== Beispiel: Komplettes Dokument mit integrierten Diagrammen
+
+Hier ist ein Beispiel für ein AsciiDoc-Dokument, das verschiedene Arten von Diagrammen integriert:
+
+[source,asciidoc]
+----
+= Systemarchitektur-Dokumentation
+:toc: left
+:numbered:
+:imagesdir: images
+
+== Überblick
+
+Dieses Dokument beschreibt die Architektur unseres Systems.
+
+== Systemkontext
+
+Das folgende Diagramm zeigt den Systemkontext:
+
+[plantuml,system-context,svg]
+....
+!include <C4/C4_Context>
+
+LAYOUT_WITH_LEGEND()
+
+Person(user, "Benutzer", "Ein Benutzer des Systems")
+System(system, "Mein System", "Das zu bauende Softwaresystem")
+System_Ext(external, "Externes System", "Ein externes System")
+
+Rel(user, system, "Benutzt")
+Rel(system, external, "Nutzt API von")
+....
+
+== Container-Diagramm
+
+image::container-diagram.svg[Container-Diagramm]
+
+== Komponentendiagramm
+
+plantuml::components.puml[format=svg]
+
+== Qualitätsanforderungen
+
+Die folgende Tabelle wurde aus Excel generiert:
+
+include::excel/quality-requirements.adoc[]
+----
+
+== Tipps und Tricks
+
+=== Performance-Optimierung
+
+* Diagramme im SVG-Format einbinden für bessere Skalierbarkeit und kleinere Dateigröße
+* Bei großen Dokumenten mit vielen Diagrammen kann die Generierung länger dauern - erwäge, Diagramme zu cachen
+* Für komplexe PlantUML-Diagramme: Preprocessor-Direktiven nutzen, um wiederholende Elemente zu definieren
+
+=== Layoutverbesserungen
+
+* Für PlantUML-Diagramme: Layoutrichtung explizit angeben (`top to bottom direction` oder `left to right direction`)
+* In Draw.io: Konsistente Farben und Formen für ähnliche Elemente verwenden
+* Diagramme mit aussagekräftigen Titeln und Legenden versehen
+
+=== Fehlersuche
+
+Wenn Diagramme nicht korrekt generiert werden:
+
+1. Prüfe die Syntax des Diagramm-Codes
+2. Überprüfe Pfade zu externen Dateien
+3. Verwende Debug-Optionen: `asciidoctor -r asciidoctor-diagram -a diagram-verbose document.adoc`
+
+== Praktische Übung
+
+Erstelle ein AsciiDoc-Dokument, das:
+
+1. Ein PlantUML-Sequenzdiagramm enthält
+2. Ein in Draw.io erstelltes und als SVG exportiertes Diagramm einbindet
+3. Eine aus Excel exportierte Tabelle enthält
+
+== Weiterführende Ressourcen
+
+* link:https://docs.asciidoctor.org/diagram-extension/latest/[AsciiDoctor Diagram Extension Dokumentation]
+* link:https://doctoolchain.org/[docToolchain Website]
+* link:https://plantuml.com/[PlantUML Website]
+* link:https://diagrams.net/[Draw.io Website]
+
+== Nächste Schritte
+
+* Weiter zu xref:markdown.adoc[Integration in Markdown]
+* Oder zu xref:automation.adoc[Automatisierung mit CI/CD]
+* Zurück zur xref:../index.adoc[Workshop-Übersicht]

--- a/src/docs/workshop/plantuml/getting-started.adoc
+++ b/src/docs/workshop/plantuml/getting-started.adoc
@@ -1,0 +1,265 @@
+= Erste Schritte mit PlantUML
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Was ist PlantUML?
+
+PlantUML ist ein Open-Source-Tool, mit dem du verschiedene Arten von UML-Diagrammen durch eine einfache textbasierte Sprache erstellen kannst. Es wurde 2009 von Arnaud Roques entwickelt und hat sich zu einem der beliebtesten Diagrams-as-Code Tools entwickelt.
+
+=== Hauptmerkmale von PlantUML
+
+* Unterstützt zahlreiche Diagrammtypen: Sequenz-, Klassen-, Komponenten-, Aktivitäts-, Anwendungsfall-, Zustands-, Objekt-, Deployment-, Timing- und Netzwerkdiagramme
+* Einfache, leicht zu erlernende Syntax
+* Integration in viele Editoren und Tools (VS Code, IntelliJ, Eclipse, etc.)
+* Exportformate: PNG, SVG, LaTeX, EPS, PDF und andere
+* Erweiterbar durch Includes und eigene Stile
+* Große Community und umfangreiche Dokumentation
+
+== Installation und Einrichtung
+
+=== Online-Nutzung (ohne Installation)
+
+Du kannst PlantUML ohne Installation über folgende Dienste nutzen:
+
+* link:http://www.plantuml.com/plantuml/uml/[PlantUML Online Server]
+* link:https://kroki.io/[Kroki.io]
+* In Gitpod ist PlantUML bereits vorinstalliert
+
+=== Lokale Installation
+
+Für die lokale Nutzung benötigst du:
+
+1. *Java Runtime Environment (JRE)*: PlantUML ist in Java geschrieben.
+2. *PlantUML JAR-Datei*: Herunterladen von link:https://plantuml.com/download[plantuml.com/download].
+3. *Graphviz* (optional): Für komplexere Layouts.
+
+[source,bash]
+----
+# PlantUML ausführen (mit Kommandozeile)
+java -jar plantuml.jar diagramm.puml
+
+# Mehrere Diagramme verarbeiten
+java -jar plantuml.jar *.puml
+----
+
+=== Integration in Editoren
+
+==== Visual Studio Code
+
+1. Installiere die Erweiterung "PlantUML" von jebbs.
+2. Du kannst Diagramme direkt im Editor vorschauen (Alt+D).
+
+==== IntelliJ IDEA
+
+1. Installiere das "PlantUML integration" Plugin.
+2. Erstelle Dateien mit .puml Endung.
+
+==== Online-Editoren
+
+* link:https://www.planttext.com/[PlantText]
+* link:https://plantuml-editor.kkeisuke.com/[PlantUML Editor]
+
+== Grundlegende Syntax
+
+Jedes PlantUML-Diagramm beginnt mit einem Start-Tag und endet mit einem End-Tag. Die Tags variieren je nach Diagrammtyp.
+
+=== Sequenzdiagramm (Beispiel)
+
+[source,plantuml]
+----
+@startuml
+Alice -> Bob: Authentifizierungsanfrage
+Bob --> Alice: Authentifizierungsantwort
+Alice -> Bob: Weitere Anfrage
+Alice <-- Bob: Weitere Antwort
+@enduml
+----
+
+=== Klassendiagramm (Beispiel)
+
+[source,plantuml]
+----
+@startuml
+class User {
+  +String username
+  +String password
+  +login(): boolean
+}
+
+class Admin extends User {
+  +resetUserPassword(User user)
+}
+
+class Customer extends User {
+  +placeOrder(Order order)
+}
+
+class Order {
+  +Date orderDate
+  +List<Product> products
+  +calculateTotal(): double
+}
+
+Customer "1" -- "*" Order: places
+@enduml
+----
+
+=== Komponentendiagramm (Beispiel)
+
+[source,plantuml]
+----
+@startuml
+package "Frontend" {
+  [Web UI] as UI
+  [API Client] as Client
+}
+
+package "Backend" {
+  [REST API] as API
+  [Business Logic] as Logic
+  [Data Access] as DAO
+}
+
+database "Database" {
+  [SQL Database] as DB
+}
+
+UI --> Client
+Client --> API
+API --> Logic
+Logic --> DAO
+DAO --> DB
+@enduml
+----
+
+== Wichtige Konzepte
+
+=== Pfeiltypen
+
+PlantUML unterscheidet verschiedene Arten von Pfeilen, je nach Beziehung oder Kommunikationsart:
+
+[source,plantuml]
+----
+@startuml
+' Synchrone Nachricht
+A -> B: Synchrone Anfrage
+
+' Asynchrone Nachricht
+A ->> B: Asynchrone Anfrage
+
+' Antwort
+B --> A: Antwort
+
+' Bidirektional
+A <-> B: Bidirektional
+
+' Abhängigkeit (in Klassendiagrammen)
+A ..> B: abhängig von
+@enduml
+----
+
+=== Styling und Formatierung
+
+Die Darstellung von Diagrammen kann angepasst werden:
+
+[source,plantuml]
+----
+@startuml
+' Farben
+rectangle "Frontend" #LightBlue {
+  [Web UI]
+}
+
+' Schriftart und -größe
+skinparam defaultFontName Arial
+skinparam defaultFontSize 12
+
+' Ausrichtung und Layout
+top to bottom direction
+@enduml
+----
+
+=== Includes und Wiederverwendung
+
+PlantUML erlaubt das Einbinden von externen Definitionen, was die Wiederverwendung und Modularität fördert:
+
+[source,plantuml]
+----
+@startuml
+!include common-styles.puml
+!include models/user.puml
+
+' Verwende die eingebundenen Definitionen
+User -> Order: erstellt
+@enduml
+----
+
+== Tipps & Tricks
+
+=== Komplexe Diagramme strukturieren
+
+* Teile große Diagramme in mehrere Dateien auf
+* Verwende includes für gemeinsame Elemente
+* Nutze Gruppierungen mit `package`, `rectangle`, `folder` etc.
+
+=== Layoutoptimierung
+
+* Verwende `top to bottom direction` oder `left to right direction`
+* Passe die Abstände mit `skinparam` an
+* Verwende explizite Positionierung mit Hidden Links: `A -[hidden]-> B`
+
+=== Debugging
+
+Wenn ein Diagramm nicht wie erwartet dargestellt wird:
+
+1. Überprüfe die Syntax auf fehlende End-Tags (`@enduml`)
+2. Versuche, das Diagramm schrittweise aufzubauen
+3. Nutze den Verbose-Modus: `java -jar plantuml.jar -verbose diagramm.puml`
+
+== Praktische Übung
+
+Erstelle ein einfaches Sequenzdiagramm, das die Anmeldung eines Benutzers zeigt:
+
+1. Erstelle eine neue Datei `login-sequence.puml`
+2. Definiere ein Sequenzdiagramm mit folgenden Akteuren:
+   * User (Person)
+   * Web Interface
+   * Authentication Service
+   * User Database
+3. Modelliere den Anmeldeablauf:
+   * User gibt Credentials ein
+   * Web Interface leitet Anfrage an Authentication Service weiter
+   * Authentication Service prüft Credentials gegen die Datenbank
+   * Rückmeldung erfolgt in umgekehrter Reihenfolge
+
+Beispiellösung:
+
+[source,plantuml]
+----
+@startuml
+actor User
+participant "Web Interface" as Web
+participant "Authentication Service" as Auth
+database "User Database" as DB
+
+User -> Web: Enter credentials
+Web -> Auth: Forward login request
+Auth -> DB: Validate credentials
+Auth <-- DB: Return user details
+Web <-- Auth: Authentication result
+User <-- Web: Login success/failure
+@enduml
+----
+
+== Weiterführende Ressourcen
+
+* link:https://plantuml.com/guide[Offizielle PlantUML-Dokumentation]
+* link:https://crashedmind.github.io/PlantUMLHitchhikersGuide/[PlantUML Hitchhiker's Guide]
+* link:https://real-world-plantuml.com/[Real World PlantUML] - Sammlung von Beispielen
+
+== Nächste Schritte
+
+* Weiter zu xref:sequence-diagrams.adoc[Sequenzdiagramme mit PlantUML]
+* Oder zurück zu xref:../index.adoc[Workshop-Übersicht]

--- a/src/docs/workshop/resources/examples.adoc
+++ b/src/docs/workshop/resources/examples.adoc
@@ -1,0 +1,375 @@
+= Beispieldiagramme
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../../images
+
+== Übersicht
+
+In diesem Abschnitt findest du eine Sammlung von Beispieldiagrammen, die du als Referenz oder Ausgangspunkt für deine eigenen Diagramme verwenden kannst. Die Beispiele decken verschiedene Diagrammtypen und Tools ab.
+
+== PlantUML-Beispiele
+
+=== Sequenzdiagramm: Bestellprozess
+
+[source,plantuml]
+----
+@startuml
+title Bestellprozess
+actor "Kunde" as Customer
+participant "Webshop Frontend" as Frontend
+participant "Bestellservice" as OrderService
+participant "Zahlungsservice" as PaymentService
+database "Bestelldatenbank" as OrderDB
+
+Customer -> Frontend: Warenkorb zur Kasse
+activate Frontend
+
+Frontend -> OrderService: createOrder(items)
+activate OrderService
+
+OrderService -> OrderDB: speichereVorläufigeBestellung()
+OrderDB --> OrderService: Bestellnummer
+
+OrderService --> Frontend: Bestellnummer, Zahlungsoptionen
+deactivate OrderService
+
+Frontend --> Customer: Zahlungsoptionen anzeigen
+Customer -> Frontend: Zahlungsmethode auswählen
+
+Frontend -> PaymentService: initializePayment(orderId, method)
+activate PaymentService
+
+PaymentService --> Frontend: Zahlungs-URL/Token
+deactivate PaymentService
+
+Frontend --> Customer: Weiterleitung zur Zahlungsseite
+deactivate Frontend
+
+Customer -> PaymentService: Zahlungsdaten eingeben
+activate PaymentService
+
+PaymentService -> OrderService: Zahlungsbestätigung
+activate OrderService
+
+OrderService -> OrderDB: Bestellung finalisieren
+OrderDB --> OrderService: Bestätigung
+
+OrderService --> PaymentService: Erfolg
+deactivate OrderService
+
+PaymentService --> Customer: Zahlungsbestätigung
+deactivate PaymentService
+
+@enduml
+----
+
+=== Klassendiagramm: E-Commerce-System
+
+[source,plantuml]
+----
+@startuml
+title E-Commerce-Klassenhierarchie
+
+package "Users" {
+  abstract class User {
+    +id: String
+    +name: String
+    +email: String
+    +register(): void
+    +login(): boolean
+    +logout(): void
+  }
+  
+  class Customer extends User {
+    +address: Address
+    +paymentMethods: List<PaymentMethod>
+    +placeOrder(cart: ShoppingCart): Order
+    +viewOrderHistory(): List<Order>
+  }
+  
+  class Admin extends User {
+    +role: String
+    +manageProducts(): void
+    +manageUsers(): void
+    +viewReports(): void
+  }
+}
+
+package "Order System" {
+  class Order {
+    +id: String
+    +customer: Customer
+    +items: List<OrderItem>
+    +date: Date
+    +status: OrderStatus
+    +calculateTotal(): Money
+    +updateStatus(status: OrderStatus): void
+  }
+  
+  class OrderItem {
+    +product: Product
+    +quantity: int
+    +calculateSubtotal(): Money
+  }
+  
+  enum OrderStatus {
+    PENDING
+    PAID
+    SHIPPED
+    DELIVERED
+    CANCELLED
+  }
+  
+  class ShoppingCart {
+    +items: List<OrderItem>
+    +addItem(product: Product, quantity: int): void
+    +removeItem(item: OrderItem): void
+    +calculateTotal(): Money
+    +checkout(): Order
+  }
+}
+
+package "Products" {
+  class Product {
+    +id: String
+    +name: String
+    +description: String
+    +price: Money
+    +category: Category
+    +isAvailable(): boolean
+  }
+  
+  class Category {
+    +id: String
+    +name: String
+    +parent: Category
+    +getFullPath(): String
+  }
+}
+
+Customer "1" -- "0..*" Order: places
+Customer "1" -- "0..1" ShoppingCart: has
+Order "1" *-- "1..*" OrderItem: contains
+OrderItem "1" -- "1" Product: references
+Product "0..*" -- "1" Category: belongs to
+
+@enduml
+----
+
+=== C4-Modell: Container-Diagramm eines Mikroservice-Systems
+
+[source,plantuml]
+----
+@startuml
+!include <C4/C4_Container>
+
+LAYOUT_WITH_LEGEND()
+
+title Container-Diagramm für ein Mikroservice-basiertes E-Commerce-System
+
+Person(customer, "Kunde", "Ein registrierter Kunde, der Produkte kaufen möchte.")
+
+System_Boundary(ecommerce_system, "E-Commerce-System") {
+    Container(web_app, "Web-Anwendung", "JavaScript, React", "Stellt die E-Commerce-Funktionalität im Browser des Kunden bereit.")
+    Container(mobile_app, "Mobile App", "Swift, Kotlin", "Stellt die E-Commerce-Funktionalität auf mobilen Geräten bereit.")
+    
+    Container(api_gateway, "API Gateway", "Java, Spring Cloud Gateway", "Einheitlicher Zugangspunkt zu allen Backend-Diensten.")
+    
+    Container(product_service, "Produktservice", "Java, Spring Boot", "Verwaltet Produkte, Kategorien und Suchfunktionen.")
+    Container(order_service, "Bestellservice", "Java, Spring Boot", "Verwaltet Bestellungen und den Bestellprozess.")
+    Container(user_service, "Benutzerservice", "Node.js, Express", "Verwaltet Benutzer, Authentifizierung und Berechtigungen.")
+    Container(payment_service, "Zahlungsservice", "Python, Flask", "Verarbeitet Zahlungen und kommuniziert mit externen Zahlungsdienstleistern.")
+    
+    ContainerDb(product_db, "Produktdatenbank", "MongoDB", "Speichert Produktinformationen, Kategorien und Suchdaten.")
+    ContainerDb(order_db, "Bestelldatenbank", "PostgreSQL", "Speichert Bestelldaten und -status.")
+    ContainerDb(user_db, "Benutzerdatenbank", "PostgreSQL", "Speichert Benutzerprofile und Anmeldedaten.")
+}
+
+System_Ext(payment_provider, "Zahlungsdienstleister", "Externer Zahlungsdienst für die Verarbeitung von Kreditkarten und anderen Zahlungsmethoden.")
+System_Ext(shipping_provider, "Versanddienstleister", "Externer Dienst für die Abwicklung des Versands von Bestellungen.")
+
+Rel(customer, web_app, "Nutzt", "HTTPS")
+Rel(customer, mobile_app, "Nutzt", "HTTPS")
+
+Rel(web_app, api_gateway, "API-Anfragen", "JSON/HTTPS")
+Rel(mobile_app, api_gateway, "API-Anfragen", "JSON/HTTPS")
+
+Rel(api_gateway, product_service, "Routen", "JSON/HTTPS")
+Rel(api_gateway, order_service, "Routen", "JSON/HTTPS")
+Rel(api_gateway, user_service, "Routen", "JSON/HTTPS")
+Rel(api_gateway, payment_service, "Routen", "JSON/HTTPS")
+
+Rel(product_service, product_db, "Lesen/Schreiben", "MongoDB Driver")
+Rel(order_service, order_db, "Lesen/Schreiben", "JDBC")
+Rel(user_service, user_db, "Lesen/Schreiben", "Sequelize ORM")
+
+Rel(order_service, product_service, "Produktverfügbarkeit prüfen", "JSON/HTTPS")
+Rel(order_service, user_service, "Benutzerdetails abrufen", "JSON/HTTPS")
+Rel(order_service, payment_service, "Zahlung initiieren", "JSON/HTTPS")
+Rel(order_service, shipping_provider, "Versand anfordern", "JSON/HTTPS")
+
+Rel(payment_service, payment_provider, "Zahlung verarbeiten", "JSON/HTTPS")
+
+@enduml
+----
+
+== Draw.io-Beispiele
+
+=== Systemkontext-Diagramm
+
+image::examples/drawio-system-context.svg[Systemkontext mit Draw.io]
+
+=== Infrastruktur-Diagramm
+
+image::examples/drawio-infrastructure.svg[Infrastruktur mit Draw.io]
+
+== Kombinierte Beispiele für Dokumentation
+
+=== arc42-Dokumentation mit integrierten Diagrammen
+
+Hier ist ein Beispiel, wie verschiedene Diagrammtypen in einer arc42-Dokumentation zusammenspielen können:
+
+* *Kontextdiagramm* (C4-Modell mit PlantUML)
+* *Container-Diagramm* (C4-Modell mit PlantUML)
+* *Lösungsstrategie* (Konzeptdiagramm mit Draw.io)
+* *Building Block View* (Komponentendiagramm mit PlantUML)
+* *Runtime View* (Sequenzdiagramme mit PlantUML)
+* *Deployment View* (Infrastrukturdiagramm mit Draw.io)
+* *Querschnittliche Konzepte* (Konzeptdiagramm mit Draw.io)
+* *Architekturentscheidungen* (Entscheidungstabellen aus Excel)
+* *Qualitätsszenarien* (Qualitätsbaum mit PlantUML)
+
+=== Living Dokumentation mit CI/CD-Integration
+
+[source,yaml]
+----
+# .github/workflows/docs.yml
+name: Documentation
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'docs/**'
+      - 'src/main/plantuml/**'
+      - 'src/main/drawio/**'
+      - '.github/workflows/docs.yml'
+
+jobs:
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      
+      - name: Install Asciidoctor and PlantUML
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ruby graphviz
+          sudo gem install asciidoctor asciidoctor-diagram
+      
+      - name: Generate PlantUML diagrams
+        run: |
+          mkdir -p docs/images/generated
+          for file in src/main/plantuml/*.puml; do
+            filename=$(basename "$file" .puml)
+            java -jar .tools/plantuml.jar -tsvg -o "../../docs/images/generated" "$file"
+          done
+      
+      - name: Export Draw.io diagrams
+        run: |
+          mkdir -p docs/images/generated
+          for file in src/main/drawio/*.drawio; do
+            filename=$(basename "$file" .drawio)
+            npx @drawio/drawio-cli -x -f svg -o "docs/images/generated/$filename.svg" "$file"
+          done
+      
+      - name: Generate Documentation
+        run: |
+          asciidoctor -r asciidoctor-diagram -D docs/generated docs/index.adoc
+      
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: docs/generated
+----
+
+== Cheatsheets
+
+=== PlantUML Cheatsheet
+
+[cols="1,1,2"]
+|===
+| Diagrammtyp | Start/Ende | Grundelemente
+
+| Sequenzdiagramm
+| @startuml / @enduml
+| actor, participant, -> (Nachricht), <- (Antwort), activate/deactivate
+
+| Klassendiagramm
+| @startuml / @enduml
+| class, interface, abstract class, extends, implements, -- (Assoziation), *-- (Komposition)
+
+| Komponentendiagramm
+| @startuml / @enduml
+| [Komponente], component, interface, -> (Verwendung), ()- (Schnittstelle)
+
+| C4 Context
+| @startuml + !include <C4/C4_Context> / @enduml
+| Person(), System(), System_Ext(), Rel()
+
+| C4 Container
+| @startuml + !include <C4/C4_Container> / @enduml
+| Container(), ContainerDb(), System_Boundary()
+|===
+
+=== Draw.io Tastenkürzel
+
+[cols="1,2"]
+|===
+| Tastenkombination | Funktion
+
+| Strg+A
+| Alles auswählen
+
+| Strg+D
+| Duplizieren
+
+| Strg+G
+| Gruppieren
+
+| Strg+Shift+G
+| Gruppierung aufheben
+
+| Strg+L
+| Verbindung erstellen
+
+| Strg+M
+| Bearbeiten (Edit)
+
+| Strg+Shift+L
+| Layout anwenden
+
+| Alt+Shift+X
+| Verbindungspunkte anzeigen/ausblenden
+|===
+
+== Weiterführende Ressourcen
+
+* link:https://real-world-plantuml.com/[Real World PlantUML] - Sammlung praktischer PlantUML-Beispiele
+* link:https://crashedmind.github.io/PlantUMLHitchhikersGuide/[PlantUML Hitchhiker's Guide]
+* link:https://drawio-app.com/blog/[Draw.io Blog] - Tipps und Tricks für Draw.io
+* link:https://c4model.com/[C4 Model] - Offizielle Website des C4-Modells
+* link:https://github.com/plantuml-stdlib/C4-PlantUML[C4-PlantUML auf GitHub]
+
+== Nächste Schritte
+
+* Zurück zu xref:../index.adoc[Workshop-Übersicht]
+* Weiter zu xref:cheatsheets.adoc[Ausführliche Cheatsheets]

--- a/src/docs/workshop/trainer-guide.adoc
+++ b/src/docs/workshop/trainer-guide.adoc
@@ -1,0 +1,138 @@
+= Anleitung für Trainer
+:toc: left
+:icons: font
+:experimental:
+:imagesdir: ../images
+
+== Überblick
+
+Diese Anleitung ist für Trainer und Workshop-Leiter gedacht, die den "Diagrams-as-Code" Workshop durchführen möchten. Sie enthält Hinweise zur Vorbereitung, Durchführung und typischen Fragen der Teilnehmer.
+
+== Vorbereitungen
+
+=== Zeitplanung
+
+Der Workshop ist modular aufgebaut und kann je nach verfügbarer Zeit angepasst werden:
+
+* *Kompletter Workshop*: 6-8 Stunden (empfohlen für ein umfassendes Verständnis)
+* *Kurzversion*: 3-4 Stunden (Fokus auf PlantUML und C4-Grundlagen)
+* *Einführung*: 1-2 Stunden (Nur Grundlagen und ein ausgewähltes Tool)
+
+Empfohlene Zeitaufteilung für den kompletten Workshop:
+
+[cols="1,2,1"]
+|===
+| Modul | Inhalt | Zeit
+
+| Grundlagen
+| Einführung, Konzepte, Vorteile
+| 30-45 Minuten
+
+| PlantUML
+| Syntax, Diagrammtypen, Übungen
+| 2-2,5 Stunden
+
+| Draw.io
+| Grundlagen, Code-Integration
+| 1-1,5 Stunden
+
+| C4 Modellierung
+| Konzepte, Implementierung mit verschiedenen Tools
+| 1,5-2 Stunden
+
+| Integration
+| Einbindung in Dokumentation, Automatisierung
+| 1-1,5 Stunden
+
+| Pausen
+| Mehrere kurze Pausen einplanen
+| 30-60 Minuten
+|===
+
+=== Technische Voraussetzungen
+
+==== Für den Trainer
+
+* Laptop mit installierter Software
+* Präsentationsmöglichkeit (Beamer, großer Bildschirm)
+* Stabile Internetverbindung
+* Vorkonfigurierte Gitpod-Umgebung zum Demonstrieren
+
+==== Für die Teilnehmer
+
+* Laptop mit Internetzugang
+* GitHub-Account (für Gitpod und Repository-Zugriff)
+* Alternativ: Installierte Tools (Java, VS Code mit Erweiterungen)
+
+=== Vor dem Workshop
+
+1. *Testlauf durchführen*: Alle Übungen und Beispiele vorher selbst durcharbeiten
+2. *Umgebung prüfen*: Gitpod-Umgebung auf Funktionalität testen
+3. *Materialien vorbereiten*: Zusätzliche Handouts oder Beispiele bei Bedarf
+4. *Teilnehmerliste*: Erfahrungslevel der Teilnehmer erfragen, um Schwerpunkte anzupassen
+
+== Durchführung des Workshops
+
+=== Einstieg
+
+* Kurze Vorstellungsrunde mit Erfahrungslevel
+* Abfrage der Erwartungen der Teilnehmer
+* Überblick über die geplanten Module und Zeiten
+* Technische Einrichtung der Arbeitsumgebung
+
+=== Didaktische Hinweise
+
+* *Hands-on*: Nach jeder theoretischen Einführung praktische Übungen durchführen
+* *Zwischenfragen*: Regelmäßig Verständnisfragen stellen
+* *Pair-Programming*: Bei größeren Übungen Teilnehmer in Paaren arbeiten lassen
+* *Tempo anpassen*: Je nach Gruppe das Tempo anpassen, Fortgeschrittene können Bonus-Aufgaben bearbeiten
+
+=== Typische Herausforderungen und Lösungen
+
+[cols="1,2"]
+|===
+| Herausforderung | Lösung
+
+| Unterschiedliche Erfahrungslevel
+| Buddy-System: Erfahrene und Anfänger zusammenbringen
+
+| Technische Probleme
+| Gitpod als robuste Alternative nutzen, Fallback-Optionen vorbereiten
+
+| Zeitmanagement
+| Module mit niedrigerer Priorität identifizieren, die bei Zeitdruck gekürzt werden können
+
+| Komplexe Syntax (besonders PlantUML)
+| Cheat-Sheets verteilen, auf einfache Beispiele fokussieren, die iterativ erweitert werden
+|===
+
+== Nach dem Workshop
+
+=== Nachbereitung
+
+* Feedback der Teilnehmer einholen
+* Workshop-Materialien zur Verfügung stellen
+* Weiterführende Ressourcen teilen
+* Kontaktmöglichkeit für Nachfragen anbieten
+
+=== Zusätzliche Ressourcen für Trainer
+
+* link:https://doctoolchain.org/[docToolchain-Dokumentation]
+* link:https://arc42.org/[arc42-Website] (für Architekturbeispiele)
+* link:https://plantuml.com/guide[PlantUML Offizielle Dokumentation]
+* link:https://c4model.com/[C4 Model - Offizielle Website]
+
+== Häufig gestellte Fragen
+
+[qanda]
+Wie integriere ich die Diagramme in größere Dokumentationsprojekte?::
+  Für AsciiDoc-basierte Projekte empfiehlt sich docToolchain. Für andere Formate wie Markdown können CI/CD-Pipelines eingerichtet werden, die die Diagramm-Generierung automatisieren.
+
+Wie gehe ich mit komplexen Diagrammen und Übersichtlichkeit um?::
+  Bei PlantUML empfiehlt sich die Nutzung von Includes, um Diagramme in wiederverwendbare Teile zu zerlegen. Bei C4 ist eine schrittweise Verfeinerung nach dem C4-Modell sinnvoll.
+
+Welches Tool ist für Anfänger am besten geeignet?::
+  Draw.io bietet den einfachsten Einstieg durch die graphische Oberfläche mit Code-Export. PlantUML ist jedoch mächtiger für strukturierte Diagramme und hat eine steilere, aber lohnende Lernkurve.
+
+Wie kann ich eigene Stilvorlagen für konsistente Diagramme erstellen?::
+  In PlantUML können Stilvorlagen als `.puml`-Dateien definiert und inkludiert werden. In Draw.io können Bibliotheken und Vorlagen erstellt und geteilt werden.


### PR DESCRIPTION
## Verbesserte Dokumentationsstruktur mit klarem Einführungs-Guide

Diese Pull Request implementiert eine strukturierte Dokumentation mit ausführlichen Anleitungen für Diagramm-als-Code Tools. Die Änderungen sollen sowohl Workshop-Teilnehmern als auch Selbstlernern einen klaren Leitfaden bieten.

### Hauptänderungen

#### 1. Erweiterte README
- Klare Erklärung des Workshops und seiner Ziele
- Detaillierte Anleitung für die Einrichtung sowohl mit Gitpod als auch lokal
- Übersicht über unterstützte Diagramm-Tools

#### 2. Strukturierte Workshop-Dokumente
- Workshops in Modulen für verschiedene Diagramm-Typen organisiert
- Klare Progression vom Einfachen zum Komplexen
- Einführungsdokumente zu jedem Tool (PlantUML, Draw.io, C4 Modell)

#### 3. Zusätzliche Ressourcen
- Trainerleitfaden mit Tipps zur Durchführung des Workshops
- Beispieldiagramme für verschiedene Anwendungsfälle
- Referenzmaterial und Cheatsheets

#### 4. Integration in Dokumentation
- Anleitung zur Einbindung von Diagrammen in AsciiDoc
- Beispiel für CI/CD-Integration

### Vorteile dieser Änderungen

- **Verbesserte Benutzerfreundlichkeit**: Neue Benutzer können sofort einsteigen
- **Strukturiertes Lernen**: Klarer Lernpfad vom Einfachen zum Komplexen
- **Praxisorientierter Ansatz**: Realitätsnahe Beispiele zeigen den tatsächlichen Nutzen
- **Flexibilität**: Unterschiedliche Lerngeschwindigkeiten werden berücksichtigt

### Hinweise
- Die in den Dokumenten beschriebenen Beispielbilder (in `images/examples/`) müssen noch erstellt werden.
- Da dies ein Workshop-Repository ist, wurden die Anleitungen in diesem ersten Schritt in deutscher Sprache erstellt, könnten aber in Zukunft zweisprachig angeboten werden.